### PR TITLE
Removed hard coded JSPDemoPortlet from name, title and modified UIDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+target

--- a/hcl_dx_jsp_demoportlet_archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/hcl_dx_jsp_demoportlet_archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -4,13 +4,16 @@
         name="hcl_dx_jsp_demoportlet_archetype">
     <fileSets>
         <fileSet>
-            <directory>src</directory>
-        </fileSet>         
-        <fileSet>
+            <directory>src/main/java</directory>
+        </fileSet>
+        <fileSet filtered="true">
             <directory>scripts</directory>
-        </fileSet>        
-        <fileSet>
+        </fileSet>
+        <fileSet filtered="true">
             <directory>.vscode</directory>
-        </fileSet>         
+        </fileSet>
+        <fileSet filtered="true">
+            <directory>src/main/webapp</directory>
+        </fileSet>
     </fileSets>
 </archetype-descriptor>

--- a/hcl_dx_jsp_demoportlet_archetype/src/main/resources/archetype-resources/.vscode/tasks.json
+++ b/hcl_dx_jsp_demoportlet_archetype/src/main/resources/archetype-resources/.vscode/tasks.json
@@ -6,13 +6,13 @@
         {
             "label": "deploy_OR_Update_Portlet",
             "type": "shell",
-            "command": "dxclient deploy-portlet -hostname localhost -dxPort 10041 -dxConnectUsername wpsadmin -dxConnectPassword wpsadmin -dxUsername wpsadmin -dxPassword wpsadmin -warFile ${workspaceFolder}/target/jspdemoportlet-1.0.war  -xmlFile ${workspaceFolder}/scripts/DeployPortlet.xml",
+            "command": "dxclient deploy-portlet -hostname localhost -dxPort 10041 -dxProtocol https -dxConnectUsername wpsadmin -dxConnectPassword wpsadmin -dxUsername wpsadmin -dxPassword wpsadmin -warFile ${workspaceFolder}/target/${artifactId}-1.0.war  -xmlFile ${workspaceFolder}/scripts/DeployPortlet.xml",
             "problemMatcher": []
         },
         {
             "label": "undeploy_Portlet",
             "type": "shell",
-            "command": "dxclient undeploy-portlet -hostname localhost -dxPort 10041 -dxConnectUsername wpsadmin -dxConnectPassword wpsadmin -dxUsername wpsadmin -dxPassword wpsadmin -xmlFile ${workspaceFolder}/scripts/UndeployPortlet.xml",
+            "command": "dxclient undeploy-portlet -hostname localhost -dxPort 10041 -dxProtocol https -dxConnectUsername wpsadmin -dxConnectPassword wpsadmin -dxUsername wpsadmin -dxPassword wpsadmin -xmlFile ${workspaceFolder}/scripts/UndeployPortlet.xml",
             "problemMatcher": []
         }
     ]

--- a/hcl_dx_jsp_demoportlet_archetype/src/main/resources/archetype-resources/pom.xml
+++ b/hcl_dx_jsp_demoportlet_archetype/src/main/resources/archetype-resources/pom.xml
@@ -4,8 +4,8 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.hcl.dx.demo</groupId>
-  <artifactId>jspdemoportlet</artifactId>
+  <groupId>${groupId}</groupId>
+  <artifactId>${artifactId}</artifactId>
   <version>1.0</version>
   <packaging>war</packaging>
 

--- a/hcl_dx_jsp_demoportlet_archetype/src/main/resources/archetype-resources/scripts/DeployPortlet.xml
+++ b/hcl_dx_jsp_demoportlet_archetype/src/main/resources/archetype-resources/scripts/DeployPortlet.xml
@@ -7,18 +7,18 @@
     <portal action="locate">
         <!-- Sample JSR 286 portlet to create or update a portlet-->
         <!-- The uid must match uid attribute of portlet-app in portlet.xml inside the war file appended with "webmod" -->
-        <web-app action="update" active="true" domain="rel" uid="com.hcl.dx.demo.JSPDemoPortlet.a7f9d0d758.webmod">
+        <web-app action="update" active="true" domain="rel" uid="${groupId}.${artifactId}.a7f9d0d758.webmod">
          <!-- Below url path will be replaced with the generated URL by DXClient after uploading the war file to remote server -->
-           <url>file:///localhost/HCL/jspdemoportlet-1.0.war</url>
+           <url>file:///localhost/HCL/${artifactId}-1.0.war</url>
 	   <!--url>file://localhost/$user_install_root$/PortalServer/deployed/archive/com.hcl.dx.demo.JSPDemoPortlet.webmod/jspdemoportlet-1.0.war</url-->
        <!-- Replace the context root and display value below with your web application context root -->
-            <context-root>/wps/JSPDemoPortlet</context-root>
-            <display-name>JSPDemoPortlet</display-name>
+            <context-root>/wps/${artifactId}</context-root>
+            <display-name>${artifactId}</display-name>
             <!-- The uid must match uid attribute of concrete-portlet-app in portlet.xml. -->
-           <portlet-app action="update" active="true" uid="com.hcl.dx.demo.JSPDemoPortlet.a7f9d0d758">
+           <portlet-app action="update" active="true" uid="${groupId}.${artifactId}.a7f9d0d758">
               <access-control externalized="false" owner="uid=wpsadmin,o=defaultWIMFileBasedRealm" private="false"/>
               <!-- The name attribute must match content of portlet-name subtag  of concrete-portlet in portlet.xml. -->
-	            <portlet action="update" active="true" objectid="JSPDemoPortlet" name="JSPDemoPortlet" uniquename="com.hcl.dx.demo.JSPDemoPortlet" /> 
+	            <portlet action="update" active="true" objectid="${artifactId}" name="${artifactId}" uniquename="${groupId}.${artifactId}" /> 
             </portlet-app>
         </web-app>
     </portal>

--- a/hcl_dx_jsp_demoportlet_archetype/src/main/resources/archetype-resources/scripts/UndeployPortlet.xml
+++ b/hcl_dx_jsp_demoportlet_archetype/src/main/resources/archetype-resources/scripts/UndeployPortlet.xml
@@ -5,7 +5,7 @@
     type="update">
     <portal action="locate">
         <!-- uid must match uid attribute of portlet-app in portlet.xml -->
-       <web-app action="delete" uid="com.hcl.dx.demo.JSPDemoPortlet.a7f9d0d758.webmod">
+       <web-app action="delete" uid="${groupId}.${artifactId}.a7f9d0d758.webmod">
        </web-app>
     </portal>
 </request>

--- a/hcl_dx_jsp_demoportlet_archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/portlet.xml
+++ b/hcl_dx_jsp_demoportlet_archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/portlet.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<portlet-app xmlns="http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd" version="2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd" id="com.hcl.dx.demo.JSPDemoPortlet.a7f9d0d758">
+<portlet-app xmlns="http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd" version="2.0" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+	xsi:schemaLocation="http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd" 
+	id="${groupId}.${artifactId}.a7f9d0d758">
 	<portlet>
-		<portlet-name>JSPDemoPortlet</portlet-name>
-		<display-name>JSPDemoPortlet</display-name>
-		<display-name xml:lang="en">JSPDemoPortlet</display-name>
+		<portlet-name>${artifactId}</portlet-name>
+		<display-name>${artifactId}</display-name>
+		<display-name xml:lang="en">${artifactId}</display-name>
 		<portlet-class>com.hcl.dx.demo.JSPDemoPortlet</portlet-class>
 		<init-param>
 			<name>wps.markup</name>
@@ -18,13 +21,13 @@
 		<supported-locale>en</supported-locale>
 		<resource-bundle>com.hcl.dx.demo.nl.JSPDemoPortletResource</resource-bundle>
 		<portlet-info>
-			<title>JSPDemoPortlet</title>
-			<short-title>JSPDemoPortlet</short-title>
-			<keywords>JSPDemoPortlet</keywords>
+			<title>${artifactId}</title>
+			<short-title>${artifactId}</short-title>
+			<keywords>${artifactId}</keywords>
 		</portlet-info>
 		<portlet-preferences>
 			<preferences-validator>com.hcl.dx.demo.demoportlet.JSPDemoPortletPreferencesValidator</preferences-validator>
 		</portlet-preferences>
 	</portlet>
-	<default-namespace>http://JSPDemoPortlet/</default-namespace>
+	<default-namespace>http://${artifactId}/</default-namespace>
 </portlet-app>

--- a/hcl_dx_jsp_demoportlet_archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/portlet.xml
+++ b/hcl_dx_jsp_demoportlet_archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/portlet.xml
@@ -26,7 +26,7 @@
 			<keywords>${artifactId}</keywords>
 		</portlet-info>
 		<portlet-preferences>
-			<preferences-validator>com.hcl.dx.demo.demoportlet.JSPDemoPortletPreferencesValidator</preferences-validator>
+			<preferences-validator>com.hcl.dx.demo.JSPDemoPortletPreferencesValidator</preferences-validator>
 		</portlet-preferences>
 	</portlet>
 	<default-namespace>http://${artifactId}/</default-namespace>

--- a/hcl_dx_jsp_demoportlet_archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/web.xml
+++ b/hcl_dx_jsp_demoportlet_archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/web.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <web-app id="JSPDemoPortlet" version="3.1" xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
-	<display-name>JSPDemoPortlet</display-name>
+	<display-name>${artifactId}</display-name>
 </web-app>


### PR DESCRIPTION
I have performed below changes -

- Used artifactId, groupId to generate displayName, portlet UIDs etc
- Added dxProtocol option to tasks for deploy and undeploy
- Fixed class name for Portlet Preference Validator

If you consider merging this PR, request to add my name in developers section in pom.xml file of hcl_dx_jsp_demoportlet_archetype.

Thanks.