### PR TITLE
md syntax issues fixed in different README.md files + help center url corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Maven Archetypes can be easily used within IDEs like Visual Studio Code, Eclipse
 
 ## Product Documentation - Help Center
 
-[Developing portlets](https://opensource.hcltechsw.com/digital-experience/latest/extend_dx/portlets_development)
+[Developing portlets](https://help.hcl-software.com/digital-experience/9.5/latest/extend_dx/portlets_development/?h=developing+portlets)
 
-[Application Programming Interfaces (APIs)](https://opensource.hcltechsw.com/digital-experience/latest/extend_dx/apis/)
+[Application Programming Interfaces (APIs)](https://help.hcl-software.com/digital-experience/9.5/latest/extend_dx/apis/?h=apis)
 
 ## HCLSoftware U - Free Education
 

--- a/hcl_dx_jsf_demoportlet_archetype/README.md
+++ b/hcl_dx_jsf_demoportlet_archetype/README.md
@@ -22,7 +22,7 @@ With this custom archetype it is possible to generate easily a ready to use HCL 
 
 * Maven needs to be installed ([Download link](https://maven.apache.org/download.cgi))  
 
-* Java 1.8 needs to be installed. At best an IBM SDK that is shipped with the IBM Websphere Application Server. For details, please check: [System Requirements](https://support.hcltechsw.com/csm?id=kb_article&sysparm_article=KB0090156)  
+* Java 1.8 needs to be installed. At best an IBM SDK that is shipped with the IBM Websphere Application Server. For details, please check: [System Requirements](https://help.hcl-software.com/digital-experience/9.5/latest/get_started/system_requirements/traditional/supported_config/#java-sdk)  
 
 * This archetype needs to be installed in Maven  
 

--- a/hcl_dx_jsf_demoportlet_archetype/README.md
+++ b/hcl_dx_jsf_demoportlet_archetype/README.md
@@ -1,78 +1,87 @@
 # DX JSF Portlet Archetype
+
 This is a custom Archetype which is based on [Maven Portlet Archetype](https://maven.apache.org/archetypes/maven-archetype-portlet/) and can be used for creating HCL Digital Experience (DX) - Java Server Faces (JSF) based - Demo Portlets. When using this archetype with Microsoft Visual Studio Code IDE, sample scripts for deployment, update and undeployment are provided with a sample JSF portlet. It is possible to use this with other IDEs as well. In that case, the .vscode folder can be ignored.
 
-With this custom archetype it is possible to generate easily a ready to use HCL DX JSF Demo portlet with a corresponding development lifecycle: 
+With this custom archetype it is possible to generate easily a ready to use HCL DX JSF Demo portlet with a corresponding development lifecycle:  
 
-# Typical Development Lifecycle
-1) [DX JSF Portlet Generation](#create-a-hcl-dx-jsf-demo-portlet-sample-project) (Source-code generation using this archetype)
-2) [WAR-File Generation](#build-the-war-file-deployment-artifact) (Building the deployment artifact)
-3) [Portlet Deployment](#deployupdate-or-undeploy-the-portlet-using-dxclient-optional) (Creates a sample XMLAccess file needed to deploy or update the portlet on a DX server, using DXClient. When using Microsoft Visual Studio Code, sample tasks are available to deploy and update the portlet on a local HCL DX server. This may be updated to work with remote HCL DX servers as well)
-4) [Optional Test it](#test-the-generated-portlet-optional) (Adding the demo portlet manually to a page)
-5) [Portlet Undeployment](#deployupdate-or-undeploy-the-portlet-using-dxclient-optional) 
-   (Create a sample XMLAccess file needed to undeploy the Portlet from a DX server using DXClient. When using Microsoft Visual Studio Code, a sample task is available to undeploy the portlet on a local HCL DX server. This may be updated to work with remote HCL DX servers as well)
+## Typical Development Lifecycle
 
+1) [DX JSF Portlet Generation](#create-an-hcl-dx-jsf-demo-portlet-sample-project) (Source-code generation using this archetype)  
+2) [WAR-File Generation](#build-the-war-file-deployment-artifact) (Building the deployment artifact)  
+3) [Portlet Deployment](#deployupdate-or-undeploy-the-portlet-using-dxclient-optional) (Creates a sample XMLAccess file needed to deploy or update the portlet on a DX server, using DXClient. When using Microsoft Visual Studio Code, sample tasks are available to deploy and update the portlet on a local HCL DX server. This may be updated to work with remote HCL DX servers as well)  
+4) [Optional Test it](#test-the-generated-portlet-optional) (Adding the demo portlet manually to a page)  
+5) [Portlet Undeployment](#deployupdate-or-undeploy-the-portlet-using-dxclient-optional) (Create a sample XMLAccess file needed to undeploy the Portlet from a DX server using DXClient. When using Microsoft Visual Studio Code, a sample task is available to undeploy the portlet on a local HCL DX server. This may be updated to work with remote HCL DX servers as well)  
 
-# Prerequistes
+## Prerequistes
 
-  ## Prerequistes to build and install the archetype
-  * Maven needs to be installed ([Download link](https://maven.apache.org/download.cgi))
+### Prerequistes to build and install the archetype
 
-  ## Prerequistes to create an HCL DX JSF Demo Portlet
-  * Maven needs to be installed ([Download link](https://maven.apache.org/download.cgi))
-  * Java 1.8 needs to be installed. At best an IBM SDK that is shipped with the IBM Websphere Application Server. For details, please check: [System Requirements](https://support.hcltechsw.com/csm?id=kb_article&sysparm_article=KB0090156) 
-  * This archetype needs to be installed in Maven
+* Maven needs to be installed ([Download link](https://maven.apache.org/download.cgi))
 
-    ## Prerequistes to use an HCL DX JSF Demo Portlet with Visual Studio Code
-  * In addition to the previous prerequisites, have the Java and Maven extensions installed. Use of this and links to downloads are detailed in [Java build tools in VS Code](https://code.visualstudio.com/docs/java/java-build).
+### Prerequistes to create an HCL DX JSF Demo Portlet
 
-  ## Prerequistes to deploy a sample HCL DX JSF Demo Portlet 
-  * When creating a new project based on this archetype, sample scripts will be created which are prepared to run with a local HCL DX server. 
-  If you want to deploy the sample WAR-file using the generated scripts, a HCL Digital Experience Server need to be running locally. If you want to deploy the WAR file on a remote DX server, the /.vscode/tasks.json script need to be changed and the config.json file of the DXClient tool need to be changed to point to this remote server. Change the hostname and dxPort, and possibly other arguments to match your server.
-  * HCL DXClient needs to be installed on the local system and the configuration settings need to pointing to a local HCL DX server instance. 
-  For details please check: 
-  [DXClient](https://opensource.hcltechsw.com/digital-experience/latest/extend_dx/development_tools/dxclient/)
+* Maven needs to be installed ([Download link](https://maven.apache.org/download.cgi))  
 
-# Install the DX archetype
+* Java 1.8 needs to be installed. At best an IBM SDK that is shipped with the IBM Websphere Application Server. For details, please check: [System Requirements](https://support.hcltechsw.com/csm?id=kb_article&sysparm_article=KB0090156)  
+
+* This archetype needs to be installed in Maven  
+
+### Prerequistes to use an HCL DX JSF Demo Portlet with Visual Studio Code
+
+* In addition to the previous prerequisites, have the Java and Maven extensions installed. Use of this and links to downloads are detailed in [Java build tools in VS Code](https://code.visualstudio.com/docs/java/java-build).  
+
+### Prerequistes to deploy a sample HCL DX JSF Demo Portlet
+
+* When creating a new project based on this archetype, sample scripts will be created which are prepared to run with a local HCL DX server. If you want to deploy the sample WAR-file using the generated scripts, a HCL Digital Experience Server need to be running locally. If you want to deploy the WAR file on a remote DX server, the /.vscode/tasks.json script need to be changed and the config.json file of the DXClient tool need to be changed to point to this remote server. Change the hostname and dxPort, and possibly other arguments to match your server.  
+
+* HCL DXClient needs to be installed on the local system and the configuration settings need to pointing to a local HCL DX server instance. For details please check [DXClient](https://help.hcl-software.com/digital-experience/9.5/latest/extend_dx/development_tools/dxclient/).
+
+## Install the DX archetype
+
 Follow the commands in the below order to install the archetype.
 
-1) After downloading the dx-portlet-development-utilities git repository, go into the hcl_dx_jsf_demoportlet_archetype folder
-2) Run ```mvn clean install``` to install the archetype JAR
+1) After downloading the dx-portlet-development-utilities git repository, go into the hcl_dx_jsf_demoportlet_archetype folder  
+2) Run ```mvn clean install``` to install the archetype JAR  
 
-# Create an HCL DX JSF Demo Portlet sample project
-Once the new archetype is installed, create a new HCL JSF Demo Portlet using the following command: 
+## Create an HCL DX JSF Demo Portlet sample project
+
+Once the new archetype is installed, create a new HCL JSF Demo Portlet using the following command:  
 
 ```mvn org.apache.maven.plugins:maven-archetype-plugin:3.1.2:generate -DarchetypeArtifactId="hcl_dx_jsf_demoportlet_archetype" -DarchetypeGroupId="com.hcl.dx.demo" -DarchetypeVersion="1.0" -DgroupId="com.hcl.dx" -DartifactId="jsfdemoportlet"```
 
-The parameters "-DarchetypeArtifactId", "DarchetypeGroupId" and "-DarchetypeVersion" values match the values of the provided archetype. Do not change these to create new DX JSF Portlets.<br> 
-For details, please check: [Introduction to archetypes - What is Archetype?](https://maven.apache.org/guides/introduction/introduction-to-archetypes.html)<br>
+The parameters "-DarchetypeArtifactId", "DarchetypeGroupId" and "-DarchetypeVersion" values match the values of the provided archetype. Do not change these to create new DX JSF Portlets. For details, please check [Introduction to archetypes - What is Archetype?](https://maven.apache.org/guides/introduction/introduction-to-archetypes.html)  
 You may want to change the "-DgroupId" and/or "-DartifactId" parameter values for your needs. For example, if you want to generate the portlet under your groupID (package-ID), just change the "-DgroupId" for example to "com.myorg.myportletpackage". You can also change the portlet name using "-DartifactId".
 
-# Build the WAR-File (Deployment artifact)
-1) Go into the project directory
-2) Run  ```mvn clean package``` to generate the HCL DX JSF Demo Portlet WAR file. It generates a WAR-file name that uses the artifactId and version in the folllowing format "(artifactID)-(archetypeVersion).war". 
-   For this example, your WAR file is created under your project folder and will look like: 
-   ```/<project-folder>/target/jsfdemoportlet-1.0.war```
+## Build the WAR-File (Deployment artifact)
 
-# Deploy/Update or Undeploy the Portlet using DXClient (Optional)
-A new portlet project generated from this custom archetype includes sample XMLAccess files to deploy, update and undeploy the HCL DX JSF Demo Portlet on a local HCL-DX server. When using Microsoft Visual Studio Code IDE you have tasks to deploy and update (both use deploy_OR_Update_Portlet), and undeploy (undeploy_Portlet). For details, check file ```./vscode/tasks.json```. If any other IDE is used, the whole /.vscode folder can be ignored and/or deleted. 
+1) Go into the project directory.  
 
-Use the following DXClient command for a manual deployment or update of the portlet:
+2) Run  ```mvn clean package``` to generate the HCL DX JSF Demo Portlet WAR file. It generates a WAR-file name that uses the artifactId and version in the folllowing format "(artifactID)-(archetypeVersion).war". For this example, your WAR file is created under your project folder and will look like: ```/<project-folder>/target/jsfdemoportlet-1.0.war```
 
-```dxclient deploy-portlet -hostname <hostname> -dxPort <port> -dxConnectUsername <user> -dxConnectPassword <password> -dxUsername <user> -dxPassword <password> -warFile <workspaceFolder>/target/jsfdemoportlet-1.0.war  -xmlFile <workspaceFolder>/scripts/DeployPortlet.xml```
+## Deploy/Update or Undeploy the Portlet using DXClient (Optional)
 
-Use the following DXClient command for a manual undeployment of the portlet:
+A new portlet project generated from this custom archetype includes sample XMLAccess files to deploy, update and undeploy the HCL DX JSF Demo Portlet on a local HCL-DX server. When using Microsoft Visual Studio Code IDE you have tasks to deploy and update (both use deploy_OR_Update_Portlet), and undeploy (undeploy_Portlet). For details, check file ```./vscode/tasks.json```. If any other IDE is used, the whole /.vscode folder can be ignored and/or deleted.  
 
-```dxclient undeploy-portlet -hostname <hostname> -dxPort <port> -dxConnectUsername <user> -dxConnectPassword <password> -dxUsername <user> -dxPassword <password> -xmlFile <workspaceFolder>/scripts/UndeployPortlet.xml```
+Use the following DXClient command for a manual deployment or update of the portlet:  
 
-# Test the generated Portlet (Optional)
-As soon as the HCL DX JSF Demo Portlet is deployed, following these steps to test the portlet:
+```dxclient deploy-portlet -hostname <hostname> -dxPort <port> -dxConnectUsername <user> -dxConnectPassword <password> -dxUsername <user> -dxPassword <password> -warFile <workspaceFolder>/target/jsfdemoportlet-1.0.war  -xmlFile <workspaceFolder>/scripts/DeployPortlet.xml```  
 
-1) Create a new empty page or use an existing one on your HCL DX Server. Ensure that the permissions are set correctly using the Practitioner Studio - Administration - Manage Pages. <br>
-See details in [Assigning access to pages, labels, and URLs](https://opensource.hcltechsw.com/digital-experience/latest/deployment/manage/portal_admin_tools/portal_user_interface/managing_pages/h_mp_access/)
-2) Add the portlet to the page. Ensure that the portlet permissions are set correctly using the Practitioner Studio - Administration - Applications - Portlets.<br> 
-See details in [Assigning access to a portlet](https://opensource.hcltechsw.com/digital-experience/latest/extend_dx/portlets_development/mng_portlets_apps_widgets/portlet_management/h_mport_access_portlets/). 
+Use the following DXClient command for a manual undeployment of the portlet:  
+
+```dxclient undeploy-portlet -hostname <hostname> -dxPort <port> -dxConnectUsername <user> -dxConnectPassword <password> -dxUsername <user> -dxPassword <password> -xmlFile <workspaceFolder>/scripts/UndeployPortlet.xml```  
+
+## Test the generated Portlet (Optional)
+
+As soon as the HCL DX JSF Demo Portlet is deployed, following these steps to test the portlet:  
+
+1) Create a new empty page or use an existing one on your HCL DX Server. Ensure that the permissions are set correctly using the Practitioner Studio - Administration - Manage Pages.  
+See details in [Assigning access to pages, labels, and URLs](https://help.hcl-software.com/digital-experience/9.5/latest/deployment/manage/portal_admin_tools/portal_user_interface/managing_pages/h_mp_access/)  
+
+2) Add the portlet to the page. Ensure that the portlet permissions are set correctly using the Practitioner Studio - Administration - Applications - Portlets.  
+See details in [Assigning access to a portlet](https://help.hcl-software.com/digital-experience/9.5/latest/extend_dx/portlets_development/mng_portlets_apps_widgets/portlet_management/h_mport_access_portlets/).  
+
 3) Open the page and test the portlet
 
-# Sample Screenshot
+## Sample Screenshot
 
-![Portlet View](./screenshots/JSFDemoPortlet.png)<br>
+![Portlet View](./screenshots/JSFDemoPortlet.png)  

--- a/hcl_dx_jsf_demoportlet_archetype/src/main/resources/archetype-resources/src/main/webapp/JSFDemoPortletView.xhtml
+++ b/hcl_dx_jsf_demoportlet_archetype/src/main/resources/archetype-resources/src/main/webapp/JSFDemoPortletView.xhtml
@@ -7,6 +7,6 @@
  
 
 <p>Hello World!</p>
-<a target="_blank" href="https://opensource.hcltechsw.com/digital-experience/latest/extend_dx/portlets_development/usage/jsf/">Find out more about the supported HCL DX JSF-API</a>
+<a target="_blank" href="https://help.hcl-software.com/digital-experience/9.5/latest/extend_dx/portlets_development/usage/jsf/">Find out more about the supported HCL DX JSF-API</a>
 
 </div>

--- a/hcl_dx_jsp_demoportlet_archetype/README.md
+++ b/hcl_dx_jsp_demoportlet_archetype/README.md
@@ -1,91 +1,103 @@
 # DX JSP Portlet Archetype
-This is a custom Archetype which is based on [Maven Portlet Archetype](https://maven.apache.org/archetypes/maven-archetype-portlet/) and can be used for creating HCL Digital Experience (DX) - Java Server Pages (JSP) based - Demo Portlets. When using this archetype with Microsoft Visual Studio Code IDE, sample scripts for deployment, update and undeployment are provided with a sample JSP portlet. It is possible to use this with other IDEs as well. In that case, the .vscode folder can be ignored.
 
-With this custom archetype it is possible to generate easily a ready to use HCL DX JSP Demo portlet with a corresponding development lifecycle: 
+This is a custom Archetype which is based on [Maven Portlet Archetype](https://maven.apache.org/archetypes/maven-archetype-portlet/) and can be used for creating HCL Digital Experience (DX) - Java Server Pages (JSP) based - Demo Portlets. When using this archetype with Microsoft Visual Studio Code IDE, sample scripts for deployment, update and undeployment are provided with a sample JSP portlet. It is possible to use this with other IDEs as well. In that case, the .vscode folder can be ignored.  
 
-# Typical Development Lifecycle
-1) [DX JSP Portlet Generation](#create-a-hcl-dx-jsp-demo-portlet-sample-project) (Source-code generation using this archetype)
-2) [WAR-File Generation](#build-the-war-file-deployment-artifact) (Building the deployment artifact)
-3) [Portlet Deployment](#deployupdate-or-undeploy-the-portlet-using-dxclient-optional) (Creates a sample XMLAccess file needed to deploy or update the portlet on a DX server, using DXClient. When using Microsoft Visual Studio Code, sample tasks are available to deploy and update the portlet on a local HCL DX server. This may be updated to work with remote HCL DX servers as well)
-4) [Optional Test it](#test-the-generated-portlet-optional) (Adding the demo portlet manually to a page)
-5) [Portlet Undeployment](#deployupdate-or-undeploy-the-portlet-using-dxclient-optional) 
-   (Create a sample XMLAccess file needed to undeploy the Portlet from a DX server using DXClient. When using Microsoft Visual Studio Code, a sample task is available to undeploy the portlet on a local HCL DX server. This may be updated to work with remote HCL DX servers as well)
+With this custom archetype it is possible to generate easily a ready to use HCL DX JSP Demo portlet with a corresponding development lifecycle:  
 
+## Typical Development Lifecycle
 
-# Prerequistes
+1) [DX JSP Portlet Generation](#create-an-hcl-dx-jsp-demo-portlet-sample-project) (Source-code generation using this archetype)  
+2) [WAR-File Generation](#build-the-war-file-deployment-artifact) (Building the deployment artifact)  
+3) [Portlet Deployment](#deployupdate-or-undeploy-the-portlet-using-dxclient-optional) (Creates a sample XMLAccess file needed to deploy or update the portlet on a DX server, using DXClient. When using Microsoft Visual Studio Code, sample tasks are available to deploy and update the portlet on a local HCL DX server. This may be updated to work with remote HCL DX servers as well)  
+4) [Optional Test it](#test-the-generated-portlet-optional) (Adding the demo portlet manually to a page)  
+5) [Portlet Undeployment](#deployupdate-or-undeploy-the-portlet-using-dxclient-optional) (Create a sample XMLAccess file needed to undeploy the Portlet from a DX server using DXClient. When using Microsoft Visual Studio Code, a sample task is available to undeploy the portlet on a local HCL DX server. This may be updated to work with remote HCL DX servers as well)
 
-  ## Prerequistes to build and install the archetype
-  * Maven needs to be installed ([Download link](https://maven.apache.org/download.cgi))
+## Prerequistes
 
-  ## Prerequistes to create an HCL DX JSP Demo Portlet
-  * Maven needs to be installed ([Download link](https://maven.apache.org/download.cgi))
-  * Java 1.8 needs to be installed. At best an IBM SDK that is shipped with the IBM Websphere Application Server. For details, please check: [System Requirements](https://support.hcltechsw.com/csm?id=kb_article&sysparm_article=KB0090156) 
-  * This archetype needs to be installed in Maven
+### Prerequistes to build and install the archetype
 
-    ## Prerequistes to use an HCL DX JSP Demo Portlet with Visual Studio Code
-  * In addition to the previous prerequisites, have the Java and Maven extensions installed. Use of this and links to downloads are detailed in [Java build tools in VS Code](https://code.visualstudio.com/docs/java/java-build).
+* Maven needs to be installed ([Download link](https://maven.apache.org/download.cgi))  
 
-  ## Prerequistes to deploy a sample HCL DX JSP Demo Portlet 
-  * When creating a new project based on this archetype, sample scripts will be created which are prepared to run with a local HCL DX server. 
-  If you want to deploy the sample WAR-file using the generated scripts, a HCL Digital Experience Server need to be running locally. If you want to deploy the WAR file on a remote DX server, the /.vscode/tasks.json script need to be changed and the config.json file of the DXClient tool need to be changed to point to this remote server. Change the hostname and dxPort, and possibly other arguments to match your server.
-  * HCL DXClient needs to be installed on the local system and the configuration settings need to pointing to a local HCL DX server instance. 
-  For details please check: 
-  [DXClient](https://opensource.hcltechsw.com/digital-experience/latest/extend_dx/development_tools/dxclient/)
+### Prerequistes to create an HCL DX JSP Demo Portlet
 
-# Install the DX archetype
-Follow the commands in the below order to install the archetype.
+* Maven needs to be installed ([Download link](https://maven.apache.org/download.cgi))  
+* Java 1.8 needs to be installed. At best an IBM SDK that is shipped with the IBM Websphere Application Server. For details, please check: [System Requirements](https://support.hcltechsw.com/csm?id=kb_article&sysparm_article=KB0090156)  
+* This archetype needs to be installed in Maven  
 
-1) After downloading the dx-portlet-development-utilities git repository, go into the hcl_dx_jsp_demoportlet_archetype folder
-2) Run ```mvn clean install``` to install the archetype JAR
+### Prerequistes to use an HCL DX JSP Demo Portlet with Visual Studio Code
 
-# Create an HCL DX JSP Demo Portlet sample project
-Once the new archetype is installed, create a new HCL JSP Demo Portlet using the following command: 
+* In addition to the previous prerequisites, have the Java and Maven extensions installed. Use of this and links to downloads are detailed in [Java build tools in VS Code](https://code.visualstudio.com/docs/java/java-build).  
+
+### Prerequistes to deploy a sample HCL DX JSP Demo Portlet
+
+* When creating a new project based on this archetype, sample scripts will be created which are prepared to run with a local HCL DX server. If you want to deploy the sample WAR-file using the generated scripts, a HCL Digital Experience Server need to be running locally. If you want to deploy the WAR file on a remote DX server, the /.vscode/tasks.json script need to be changed and the config.json file of the DXClient tool need to be changed to point to this remote server. Change the hostname and dxPort, and possibly other arguments to match your server.  
+
+* HCL DXClient needs to be installed on the local system and the configuration settings need to pointing to a local HCL DX server instance. For details please check [DXClient](https://help.hcl-software.com/digital-experience/9.5/latest/extend_dx/development_tools/dxclient/).
+
+## Install the DX archetype
+
+Follow the commands in the below order to install the archetype.  
+
+1) After downloading the dx-portlet-development-utilities git repository, go into the hcl_dx_jsp_demoportlet_archetype folder.  
+2) Run ```mvn clean install``` to install the archetype JAR.  
+
+## Create an HCL DX JSP Demo Portlet sample project
+
+Once the new archetype is installed, create a new HCL JSP Demo Portlet using the following command:  
 
 ```mvn org.apache.maven.plugins:maven-archetype-plugin:3.1.2:generate -DarchetypeArtifactId="hcl_dx_jsp_demoportlet_archetype" -DarchetypeGroupId="com.hcl.dx.demo" -DarchetypeVersion="1.0" -DgroupId="com.hcl.dx" -DartifactId="jspdemoportlet"```
 
-The parameters "-DarchetypeArtifactId", "DarchetypeGroupId" and "-DarchetypeVersion" values match the values of the provided archetype. Do not change these to create new DX JSP Portlets.<br> 
-For details, please check: [Introduction to archetypes - What is Archetype?](https://maven.apache.org/guides/introduction/introduction-to-archetypes.html)<br>
-You may want to change the "-DgroupId" and/or "-DartifactId" parameter values for your needs. For example, if you want to generate the portlet under your groupID (package-ID), just change the "-DgroupId" for example to "com.myorg.myportletpackage". You can also change the portlet name using "-DartifactId".
+The parameters "-DarchetypeArtifactId", "DarchetypeGroupId" and "-DarchetypeVersion" values match the values of the provided archetype. Do not change these to create new DX JSP Portlets.  
+For details, please check [Introduction to archetypes - What is Archetype?](https://maven.apache.org/guides/introduction/introduction-to-archetypes.html)  
+You may want to change the "-DgroupId" and/or "-DartifactId" parameter values for your needs. For example, if you want to generate the portlet under your groupID (package-ID), just change the "-DgroupId" for example to "com.myorg.myportletpackage". You can also change the portlet name using "-DartifactId".  
 
-# Build the WAR-File (Deployment artifact)
-1) Go into the project directory
-2) Run  ```mvn clean package``` to generate the HCL DX JSP Demo Portlet WAR file. It generates a WAR-file name that uses the artifactId and version in the folllowing format "(artifactID)-(archetypeVersion).war". 
-   For this example, your WAR file is created under your project folder and will look like: 
+## Build the WAR-File (Deployment artifact)
+
+1) Go into the project directory.  
+2) Run  ```mvn clean package``` to generate the HCL DX JSP Demo Portlet WAR file. It generates a WAR-file name that uses the artifactId and version in the folllowing format "(artifactID)-(archetypeVersion).war".  
+   For this example, your WAR file is created under your project folder and will look like:  
    ```/<project-folder>/target/jspdemoportlet-1.0.war```
 
-# Deploy/Update or Undeploy the Portlet using DXClient (Optional)
-A new portlet project generated from this custom archetype includes sample XMLAccess files to deploy, update and undeploy the HCL DX JSP Demo Portlet on a local HCL-DX server. When using Microsoft Visual Studio Code IDE you have tasks to deploy and update (both use deploy_OR_Update_Portlet), and undeploy (undeploy_Portlet). For details, check file ```./vscode/tasks.json```. If any other IDE is used, the whole /.vscode folder can be ignored and/or deleted. 
+## Deploy/Update or Undeploy the Portlet using DXClient (Optional)
 
-Use the following DXClient command for a manual deployment or update of the portlet:
+A new portlet project generated from this custom archetype includes sample XMLAccess files to deploy, update and undeploy the HCL DX JSP Demo Portlet on a local HCL-DX server. When using Microsoft Visual Studio Code IDE you have tasks to deploy and update (both use deploy_OR_Update_Portlet), and undeploy (undeploy_Portlet). For details, check file ```./vscode/tasks.json```. If any other IDE is used, the whole /.vscode folder can be ignored and/or deleted.  
 
-```dxclient deploy-portlet -hostname <hostname> -dxPort <port> -dxConnectUsername <user> -dxConnectPassword <password> -dxUsername <user> -dxPassword <password> -warFile <workspaceFolder>/target/jspdemoportlet-1.0.war  -xmlFile <workspaceFolder>/scripts/DeployPortlet.xml```
+Use the following DXClient command for a manual deployment or update of the portlet:  
 
-Use the following DXClient command for a manual undeployment of the portlet:
+```dxclient deploy-portlet -hostname <hostname> -dxPort <port> -dxConnectUsername <user> -dxConnectPassword <password> -dxUsername <user> -dxPassword <password> -warFile <workspaceFolder>/target/jspdemoportlet-1.0.war  -xmlFile <workspaceFolder>/scripts/DeployPortlet.xml```  
 
-```dxclient undeploy-portlet -hostname <hostname> -dxPort <port> -dxConnectUsername <user> -dxConnectPassword <password> -dxUsername <user> -dxPassword <password> -xmlFile <workspaceFolder>/scripts/UndeployPortlet.xml```
+Use the following DXClient command for a manual undeployment of the portlet:  
 
-# Test the generated Portlet (Optional)
-As soon as the HCL DX JSP Demo Portlet is deployed, following these steps to test the portlet:
+```dxclient undeploy-portlet -hostname <hostname> -dxPort <port> -dxConnectUsername <user> -dxConnectPassword <password> -dxUsername <user> -dxPassword <password> -xmlFile <workspaceFolder>/scripts/UndeployPortlet.xml```  
 
-1) Create a new empty page or use an existing one on your HCL DX Server. Ensure that the permissions are set correctly using the Practitioner Studio - Administration - Manage Pages. <br>
-See details in [Assigning access to pages, labels, and URLs](https://opensource.hcltechsw.com/digital-experience/latest/deployment/manage/portal_admin_tools/portal_user_interface/managing_pages/h_mp_access/)
-2) Add the portlet to the page. Ensure that the portlet permissions are set correctly using the Practitioner Studio - Administration - Applications - Portlets.<br> 
-See details in [Assigning access to a portlet](https://opensource.hcltechsw.com/digital-experience/latest/extend_dx/portlets_development/mng_portlets_apps_widgets/portlet_management/h_mport_access_portlets/). 
-3) Open the page and test the portlet
+## Test the generated Portlet (Optional)
 
-# Sample Screenshots
+As soon as the HCL DX JSP Demo Portlet is deployed, following these steps to test the portlet:  
 
-  ## Portlet View
-  ![Portlet View](./screenshots/portlet_view.png)<br>
+1) Create a new empty page or use an existing one on your HCL DX Server. Ensure that the permissions are set correctly using the Practitioner Studio - Administration - Manage Pages.  
+See details in [Assigning access to pages, labels, and URLs](https://help.hcl-software.com/digital-experience/9.5/latest/deployment/manage/portal_admin_tools/portal_user_interface/managing_pages/h_mp_access/).  
+2) Add the portlet to the page. Ensure that the portlet permissions are set correctly using the Practitioner Studio - Administration - Applications - Portlets.  
+See details in [Assigning access to a portlet](https://help.hcl-software.com/digital-experience/9.5/latest/extend_dx/portlets_development/mng_portlets_apps_widgets/portlet_management/h_mport_access_portlets/).  
+3) Open the page and test the portlet.  
+
+## Sample Screenshots
+
+### Portlet View
+
+  ![Portlet View](./screenshots/portlet_view.png)  
   
-  ## Portlet View with value
-  ![Portlet View with value](./screenshots/portlet_view_with_value.png)<br>
+### Portlet View with value
 
-  ## Edit Mode - Menu
-  ![Edit Mode - Menu](./screenshots/portlet_edit_menu.png)<br>
+  ![Portlet View with value](./screenshots/portlet_view_with_value.png)  
+
+### Edit Mode - Menu
+
+  ![Edit Mode - Menu](./screenshots/portlet_edit_menu.png)  
   
-  ## Add a Bookmark
-  ![Add a Bookmark](./screenshots/portlet_add_bookmark.png)<br>
+### Add a Bookmark
 
-  ## Portlet View - Bookmark added
-  ![Portlet View - Bookmark added](./screenshots/portlet_with_bookmark_mySamplePage_added.png)<br>
+  ![Add a Bookmark](./screenshots/portlet_add_bookmark.png)  
+
+### Portlet View - Bookmark added
+
+  ![Portlet View - Bookmark added](./screenshots/portlet_with_bookmark_mySamplePage_added.png)  

--- a/hcl_dx_jsp_demoportlet_archetype/README.md
+++ b/hcl_dx_jsp_demoportlet_archetype/README.md
@@ -21,7 +21,7 @@ With this custom archetype it is possible to generate easily a ready to use HCL 
 ### Prerequistes to create an HCL DX JSP Demo Portlet
 
 * Maven needs to be installed ([Download link](https://maven.apache.org/download.cgi))  
-* Java 1.8 needs to be installed. At best an IBM SDK that is shipped with the IBM Websphere Application Server. For details, please check: [System Requirements](https://support.hcltechsw.com/csm?id=kb_article&sysparm_article=KB0090156)  
+* Java 1.8 needs to be installed. At best an IBM SDK that is shipped with the IBM Websphere Application Server. For details, please check: [System Requirements](https://help.hcl-software.com/digital-experience/9.5/latest/get_started/system_requirements/traditional/supported_config/#java-sdk)  
 * This archetype needs to be installed in Maven  
 
 ### Prerequistes to use an HCL DX JSP Demo Portlet with Visual Studio Code

--- a/page_creation_utility/README.md
+++ b/page_creation_utility/README.md
@@ -70,7 +70,7 @@ There are two options available to deploy this application. Using the dxclient t
 
 ### DXClient Deployment
 
-You may want to use the **DXClient** to deploy this sample portlet. This repository already contain a ready-to-use [DeployPortlet.xml](https://opensource.hcltechsw.com/digital-experience/latest/deployment/manage/portal_admin_tools/xml_config_interface/working_xml_config_interface/using_xml_config_cmd_line/adxmltsk_creat_mod_resrcs/?h=deployportlet.xml) file in the deploy folder that contain all xml required information for the DX-environment to deploy the portlet. Please use the following steps to deploy the portlet with the dx-client tool:  
+You may want to use the **DXClient** to deploy this sample portlet. This repository already contain a ready-to-use [DeployPortlet.xml](https://help.hcl-software.com/digital-experience/9.5/latest/deployment/manage/portal_admin_tools/xml_config_interface/working_xml_config_interface/using_xml_config_cmd_line/adxmltsk_creat_mod_resrcs/?h=creating+modifying+resources+and) file in the deploy folder that contain all xml required information for the DX-environment to deploy the portlet. Please use the following steps to deploy the portlet with the dx-client tool:  
 
 1. copy the war file from the **target** directory to the **deploy** folder.
 
@@ -118,5 +118,5 @@ Here an screenshot as an example, when the portlet will be added on a new sibbli
 
 ## Related Documents
 
-To learn how to develop Java Portlets, you may use [Help Center Portlet Development](https://opensource.hcltechsw.com/digital-experience/CF223/extend_dx/portlets_development/).
-For details on APIs used in the utility.java, refer to the following links: [Controller SPI](https://opensource.hcltechsw.com/digital-experience/latest/extend_dx/apis/controller_spi/) and [Model SPI](https://opensource.hcltechsw.com/digital-experience/latest/extend_dx/apis/model_spi/).  
+To learn how to develop Java Portlets, you may use [Help Center Portlet Development](https://help.hcl-software.com/digital-experience/9.5/latest/extend_dx/portlets_development/).
+For details on APIs used in the utility.java, refer to the following links: [Controller SPI](https://help.hcl-software.com/digital-experience/9.5/latest/extend_dx/apis/controller_spi/) and [Model SPI](https://help.hcl-software.com/digital-experience/9.5/latest/extend_dx/apis/model_spi/).  


### PR DESCRIPTION
Fixed md syntax issues in different README.md files + updated the help-center URLs in the different files to point now to the newest public URLs.